### PR TITLE
Fix jsfeatures.in ES6 link

### DIFF
--- a/es6-features.md
+++ b/es6-features.md
@@ -17,7 +17,7 @@
   Quick samples and descriptions of all the various ES6 capabilities  
 
 - **Javascript Features**  
-  http://jsfeatures.in/#ES6  
+  https://jsfeatures.in/ES6  
   More samples of features in ES5, ES6, and ES7
 
 - **ES6 - The Bits You'll Actually Use**  


### PR DESCRIPTION
The jsfeatures.in ES6 link appears to have changed.

The old link just shows the ES5 page (which is the site index page). The
ES6 anchor does not exist.
http://jsfeatures.in/#ES6

The new link shows the ES6 page.
https://jsfeatures.in/ES6