### PR TITLE
Link fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ You might also want to check out my categorized list of Redux-related addons, li
   - [Redux Architecture and Best Practices](./redux-architecture.md)
   - [React/Redux Performance](react-performance.md)
 - **React**:
-  - [React Implementation and Concepts](./react-implementation)
+  - [React Implementation and Concepts](./react-implementation.md)
   - [React and Forms](./react-forms.md)
   - [React and AJAX](./react-ajax.md)
   - [React Styling](./react-styling.md)


### PR DESCRIPTION
# Formatting

Please follow the existing formatting for each entry.  In order to get newlines without paragraph breaks, each entry should have two spaces at the end of the line after both the URL and the title.  Also, two-space indents before the URL and the description.  Example:

```markdown
- **Link Title**<space><space>  
<space><space>http://example.com<space><space>  
<space><space>Link description here
```

Result:

- **Link Title**  
  http://example.com  
  Link description here
  
Please do _not_ strip whitespace for existing entries!

