### PR TITLE
Missing Webpack Dashboard link

### DIFF
--- a/webpack-tutorials.md
+++ b/webpack-tutorials.md
@@ -168,4 +168,5 @@ Also see the [Awesome Webpack list](https://github.com/d3viant0ne/awesome-webpac
   An experiment to make Webpack configs testable and maintainable
   
 - **Webpack Dashboard**  
+  https://github.com/FormidableLabs/webpack-dashboard  
   A CLI dashboard for your webpack dev server


### PR DESCRIPTION
# Formatting

Please follow the existing formatting for each entry.  In order to get newlines without paragraph breaks, each entry should have two spaces at the end of the line after both the URL and the title.  Also, two-space indents before the URL and the description.  Example:

```markdown
- **Link Title**<space><space>  
<space><space>http://example.com<space><space>  
<space><space>Link description here
```

Result:

- **Link Title**  
  http://example.com  
  Link description here
  
Please do _not_ strip whitespace for existing entries!

