### PR TITLE
Link to higher order components video is unavailable

### DIFF
--- a/react-component-patterns.md
+++ b/react-component-patterns.md
@@ -288,7 +288,7 @@
   Comparisons and examples for these two component patterns
   
 - **ReactCasts: Higher Order Components**  
-  https://youtu.be/6nVxCWUAEPM  
+  https://www.youtube.com/watch?v=LTunyI2Oyzw
   A screencast that walks through the idea and usage of Higher Order Components
   
 - **ReactCasts: Function as Child Component**  


### PR DESCRIPTION
The current link to the video about higher order components made by ReactCasts seems unavailable to me so I searched for a working video corresponding to ReactCasts.
