### PR TITLE
Remove broken link

### DIFF
--- a/react-routing.md
+++ b/react-routing.md
@@ -165,10 +165,6 @@
   https://medium.com/@nesbtesh/dealing-with-authentication-in-react-cadb679fbc0f  
   Some short examples of saving an authentication token, writing queries to use and update that token, and checking the token when rendering components.
   
-- **Role based routing with React and Redux**  
-  http://crazysigma.com/blogs/2017/04/16/role-based-routing-react-redux/  
-  A description of a fairly simple approach for defining role-based handling of routes, with sample code.
-  
 - **Preact Authentication Tutorial**  
   https://auth0.com/blog/preact-authentication-tutorial/  
   A tutorial that demonstrates how to build an app with Preact, including authentication, and makes some comparisons to doing so in React.


### PR DESCRIPTION
This is the link that was broken: http://ww17.crazysigma.com/blogs/2017/04/16/role-based-routing-react-redux/ . I also checked for cached versions of it, but couldn't find any.
