### PR TITLE
 Change 'react-forms/Forms in React and Redux' link and remove duplicate entry

### DIFF
--- a/react-forms.md
+++ b/react-forms.md
@@ -97,10 +97,6 @@
   https://blog.risingstack.com/handling-react-forms-with-mobx-observables/  
   Some examples of working with forms in React, using MobX for the data management.
   
-- **Forms in React and Redux**  
-  http://x-team.com/2016/02/tutorial-forms-in-react-and-redux/  
-  A good example of how to set up form handling in conjunction with a Redux store.
-  
 - **Radio Buttons and Checkboxes in React**  
   http://react.tips/radio-buttons-in-reactjs/  
   http://react.tips/checkboxes-in-react/  

--- a/react-forms.md
+++ b/react-forms.md
@@ -82,7 +82,7 @@
   Covers the basics of implementing form rendering, updates, and validation, in plain JS
   
 - **Forms in React and Redux**  
-  http://x-team.com/2016/02/tutorial-forms-in-react-and-redux/  
+  https://x-team.com/blog/tutorial-forms-in-react-and-redux/  
   Demonstrates building a simple set of wrapper components to manage forms using React and Redux
   
 - **Not-so-simple Forms with React**  


### PR DESCRIPTION
Fix #96

This entry was also duplicate in the react-forms file, but each entry had a different description. I removed one.