### PR TITLE
fix: Remove experimental proposal warning from React Hooks section

### DIFF
--- a/react-hooks.md
+++ b/react-hooks.md
@@ -1,7 +1,5 @@
 ### React Hooks
 
-> **Note**: Hooks are still an **experimental proposal, available in an alpha release**.  The API will likely change.  Keep that in mind as you try them out.
-
 
 #### Official Resources
 


### PR DESCRIPTION
The React Hooks API was officially released in v16.8, therefore
the warning is no longer relevant :)
