### PR TITLE
Remove dead link to Planet React

### DIFF
--- a/community-resources.md
+++ b/community-resources.md
@@ -51,10 +51,6 @@
   https://github.com/tuchk4/awesome-create-react-app  
   A collection of articles, links, issues, and information on how to use and customize the Create-React-App tool.
   
-- **Planet React**  
-  https://www.planet-react.org/  
-  A blog aggregator that collects posts from dozens of blogs written by members of the React community.  An excellent resource.
-  
 - **Awesome CSS-in-JS**  
   https://github.com/tuchk4/awesome-css-in-js  
   A collection of awesome things regarding  CSS in JS approaches


### PR DESCRIPTION
Chrome gives a certificate misconfiguration error, and if you actually visit the link, the domain appears to be parked by a Brazilian supermarket chain

Credit to @abrown945 for discovering

https://www.planet-react.org/

![image](https://user-images.githubusercontent.com/927220/70392756-5ab5ef80-19b1-11ea-9f84-42f13728897d.png)

![image](https://user-images.githubusercontent.com/927220/70392782-8a64f780-19b1-11ea-9e06-82cc302b3e65.png)

Portuguese to English translation from Google Translate:

![image](https://user-images.githubusercontent.com/927220/70392775-7c16db80-19b1-11ea-8d71-f9a72b5eb619.png)
