### PR TITLE
fix broken link on styling in react

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ If you are new to React, try reading these articles in order.
 ### Styles
   - [Styling in React](https://www.kirupa.com/react/styling_in_react.htm)  
     An introduction to using React's built-in inline styling abilities
-  - [How To Style React](http://andrewhfarmer.com/how-to-style-react/)  
+  - [How To Style React](https://www.javascriptstuff.com/how-to-style-react/)  
     An excellent overview of the four major ways to deal with styles in React, and what the various tools are. Includes a decision tree to help you decide what to use.
 
 


### PR DESCRIPTION
Visiting the most recent copy of the original link on the wayback machine, it's [this](http://web.archive.org/web/20190111132559/http://andrewhfarmer.com/how-to-style-react) which redirects to [here](http://web.archive.org/web/20180429195243/https://www.javascriptstuff.com/how-to-style-react/). The website it redirects to is still online and doesn't need the wayback maching to view, this commit uses the new link.