### PR TITLE
Update dead link of conversational UI example

### DIFF
--- a/redux-ui-management.md
+++ b/redux-ui-management.md
@@ -105,7 +105,7 @@
   Thoughts on the merits of using the Redux-Form library
   
 - **Conversational sign-up form UI with React and Redux**  
-  http://jsforallof.us/2016/09/08/conversational-sign-up-form-ui-with-react-and-redux/  
+  https://web.archive.org/web/20190715044522/http://jsforallof.us/2016/09/08/conversational-sign-up-form-ui-with-react-and-redux/
   An example of form management with Redux
   
 - **Should you store your form state in Redux?**  


### PR DESCRIPTION
The link for `Conversational sign-up form UI with React and Redux` is dead. This PR updates it to the latest snapshot from `archive.org`.